### PR TITLE
Add README.md and LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,165 @@
+                   GNU LESSER GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+
+  This version of the GNU Lesser General Public License incorporates
+the terms and conditions of version 3 of the GNU General Public
+License, supplemented by the additional permissions listed below.
+
+  0. Additional Definitions.
+
+  As used herein, "this License" refers to version 3 of the GNU Lesser
+General Public License, and the "GNU GPL" refers to version 3 of the GNU
+General Public License.
+
+  "The Library" refers to a covered work governed by this License,
+other than an Application or a Combined Work as defined below.
+
+  An "Application" is any work that makes use of an interface provided
+by the Library, but which is not otherwise based on the Library.
+Defining a subclass of a class defined by the Library is deemed a mode
+of using an interface provided by the Library.
+
+  A "Combined Work" is a work produced by combining or linking an
+Application with the Library.  The particular version of the Library
+with which the Combined Work was made is also called the "Linked
+Version".
+
+  The "Minimal Corresponding Source" for a Combined Work means the
+Corresponding Source for the Combined Work, excluding any source code
+for portions of the Combined Work that, considered in isolation, are
+based on the Application, and not on the Linked Version.
+
+  The "Corresponding Application Code" for a Combined Work means the
+object code and/or source code for the Application, including any data
+and utility programs needed for reproducing the Combined Work from the
+Application, but excluding the System Libraries of the Combined Work.
+
+  1. Exception to Section 3 of the GNU GPL.
+
+  You may convey a covered work under sections 3 and 4 of this License
+without being bound by section 3 of the GNU GPL.
+
+  2. Conveying Modified Versions.
+
+  If you modify a copy of the Library, and, in your modifications, a
+facility refers to a function or data to be supplied by an Application
+that uses the facility (other than as an argument passed when the
+facility is invoked), then you may convey a copy of the modified
+version:
+
+   a) under this License, provided that you make a good faith effort to
+   ensure that, in the event an Application does not supply the
+   function or data, the facility still operates, and performs
+   whatever part of its purpose remains meaningful, or
+
+   b) under the GNU GPL, with none of the additional permissions of
+   this License applicable to that copy.
+
+  3. Object Code Incorporating Material from Library Header Files.
+
+  The object code form of an Application may incorporate material from
+a header file that is part of the Library.  You may convey such object
+code under terms of your choice, provided that, if the incorporated
+material is not limited to numerical parameters, data structure
+layouts and accessors, or small macros, inline functions and templates
+(ten or fewer lines in length), you do both of the following:
+
+   a) Give prominent notice with each copy of the object code that the
+   Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the object code with a copy of the GNU GPL and this license
+   document.
+
+  4. Combined Works.
+
+  You may convey a Combined Work under terms of your choice that,
+taken together, effectively do not restrict modification of the
+portions of the Library contained in the Combined Work and reverse
+engineering for debugging such modifications, if you also do each of
+the following:
+
+   a) Give prominent notice with each copy of the Combined Work that
+   the Library is used in it and that the Library and its use are
+   covered by this License.
+
+   b) Accompany the Combined Work with a copy of the GNU GPL and this license
+   document.
+
+   c) For a Combined Work that displays copyright notices during
+   execution, include the copyright notice for the Library among
+   these notices, as well as a reference directing the user to the
+   copies of the GNU GPL and this license document.
+
+   d) Do one of the following:
+
+       0) Convey the Minimal Corresponding Source under the terms of this
+       License, and the Corresponding Application Code in a form
+       suitable for, and under terms that permit, the user to
+       recombine or relink the Application with a modified version of
+       the Linked Version to produce a modified Combined Work, in the
+       manner specified by section 6 of the GNU GPL for conveying
+       Corresponding Source.
+
+       1) Use a suitable shared library mechanism for linking with the
+       Library.  A suitable mechanism is one that (a) uses at run time
+       a copy of the Library already present on the user's computer
+       system, and (b) will operate properly with a modified version
+       of the Library that is interface-compatible with the Linked
+       Version.
+
+   e) Provide Installation Information, but only if you would otherwise
+   be required to provide such information under section 6 of the
+   GNU GPL, and only to the extent that such information is
+   necessary to install and execute a modified version of the
+   Combined Work produced by recombining or relinking the
+   Application with a modified version of the Linked Version. (If
+   you use option 4d0, the Installation Information must accompany
+   the Minimal Corresponding Source and Corresponding Application
+   Code. If you use option 4d1, you must provide the Installation
+   Information in the manner specified by section 6 of the GNU GPL
+   for conveying Corresponding Source.)
+
+  5. Combined Libraries.
+
+  You may place library facilities that are a work based on the
+Library side by side in a single library together with other library
+facilities that are not Applications and are not covered by this
+License, and convey such a combined library under terms of your
+choice, if you do both of the following:
+
+   a) Accompany the combined library with a copy of the same work based
+   on the Library, uncombined with any other library facilities,
+   conveyed under the terms of this License.
+
+   b) Give prominent notice with the combined library that part of it
+   is a work based on the Library, and explaining where to find the
+   accompanying uncombined form of the same work.
+
+  6. Revised Versions of the GNU Lesser General Public License.
+
+  The Free Software Foundation may publish revised and/or new versions
+of the GNU Lesser General Public License from time to time. Such new
+versions will be similar in spirit to the present version, but may
+differ in detail to address new problems or concerns.
+
+  Each version is given a distinguishing version number. If the
+Library as you received it specifies that a certain numbered version
+of the GNU Lesser General Public License "or any later version"
+applies to it, you have the option of following the terms and
+conditions either of that published version or of any later version
+published by the Free Software Foundation. If the Library as you
+received it does not specify a version number of the GNU Lesser
+General Public License, you may choose any version of the GNU Lesser
+General Public License ever published by the Free Software Foundation.
+
+  If the Library as you received it specifies that a proxy can decide
+whether future versions of the GNU Lesser General Public License shall
+apply, that proxy's public statement of acceptance of any version is
+permanent authorization for you to choose that version for the
+Library.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# rebol-server
+
+This repository contains bash scripts for creating a small Android .APK
+package, that bundles an ARM-based Rebol interpreter ["Ren-C branch"][1]) with
+a very tiny web server (implemented in Rebol).
+
+Then it also includes a *second* Rebol interpreter, which is compiled to
+[WebAssembly][2]...plus a cache of a web-based interactive console called
+[Replpad-JS][3].
+
+[1]: https://github.com/metaeducation/ren-c
+[2]: https://webassembly.org/
+[3]: https://github.com/hostilefork/replpad-js
+
+Rebol interpreters pride themselves on being small--so it's not a big deal to
+have two of them in the package.  But...why, especially considering that you
+can simply run ReplPad-JS from the network using the phone's native browser?
+
+Because:
+
+* The web console can be used offline.  Also, there is a kind of an "app store"
+  concept--where GitHub repositories containing other interesting Rebol code
+  can be downloaded and cached locally as well.
+
+* The Android-native Rebol that is doing the local serving can act as a
+  backchannel for capabilities that an ordinary website couldn't do.  Examples
+  would be reading or writing files from the phone's internal storage, or
+  fetching URLs that are not CORS-enabled.
+
+*(Note: Since such backchannels can ultimately represent security risks, use
+good judgment--as you would with any programming tool--when it comes to running
+code from untrusted sources!!!)*
+
+
+## Building the .APK
+
+The bash scripts are designed to be able to run even on something like
+[Termux][4], so you can run them and build the .APK on the phone itself!  The
+scripts just pull down the latest executable from [Ren-C's Travis][5], so
+there's no need to do any C compilation of Rebol itself on the phone (although
+you certainly can!).
+
+[4]: https://termux.com/
+[5]: https://travis-ci.org/metaeducation/ren-c
+
+So really the main thing to do is make sure you have the right Android packing
+tools installed.  You'll need to `apt install` the following:
+
+* `zip`
+* `dx`
+* `apksigner`
+* `zipalign`
+* `javac` *or* `ecj`
+
+If all those are in place, you can run `bash build.bash` and it should
+"just work".  If not, please raise an issue:
+
+https://github.com/metaeducation/rebol-server/issues
+
+
+## License
+
+* Rebol 3 (including the Ren-C branch) is covered by the [Apache 2 License][6]
+* The Rebol JavaScript extension is covered by the [LGPL 3.0][7]
+* ReplPad-JS is also LGPL 3.0.
+
+The rebol-server packaging code is Copyright (c) 2019 by Giulio Lunati, and is
+another LGPL 3.0 project.
+
+Any "apps" that are cached and interact with the rebol-server are governed by
+whatever license they state.
+
+[6]: https://www.apache.org/licenses/LICENSE-2.0
+[7]: https://webassembly.org/
+
+
+## Future Directions
+
+It would be nice if the bash scripts were ported to Rebol. :-)  It would also
+be good if the packaging process could be Rebol-based, without needing to
+depend on Java or other code.  (So having something like a `%jarsigner.reb`.)
+
+Right now, the Android build of Rebol is really just a typical POSIX target.
+So the number of "superpowers" it is able to grant to the web app are pretty
+much limited to local file access--as well as more generalized network access
+than is available to the average website.
+
+However...it would be possible to create "extensions" that would use APIs from
+the [Android NDK][8].  That would permit the Rebol webserver to do things like
+take pictures, or read the GPS, or whatever.
+
+[8]: https://developer.android.com/ndk
+
+One area that is **not** likely to be of much interest (to the core Rebol/Ren-C
+developers) is trying to work with native Android GUI widgets.  That's because
+the aim of this project is largely to embrace the trend toward browser-based
+development, and "Progressive Web Apps":
+
+https://en.wikipedia.org/wiki/Progressive_web_applications
+
+...but the hope is to try doing so with a WebAssembly-based Rebol playing a big
+role in that picture.


### PR DESCRIPTION
Explains the gist of what the project is about, and puts the license
under the LGPL 3.0, to match ReplPad-JS and the JavaScript extension.